### PR TITLE
Skip unisa online classes

### DIFF
--- a/lib/scraper/unisa_timetables_public.rb
+++ b/lib/scraper/unisa_timetables_public.rb
@@ -90,7 +90,7 @@ module Scraper
       timetable_rows = timetable.children
       timetable_rows.select {|row| !row.text?}.each do |row|
 
-        catch :externalclass do
+        catch :invalidclass do
           row_class = row['class']
           case row_class
           when "OptionRow"
@@ -128,12 +128,16 @@ module Scraper
                 break
               end
             end
+            attendance = timetable_columns[TimetableColumn::ATTENDANCE].text
             class_component = timetable_columns[TimetableColumn::COMPONENT].text
 
             # Skip external components as they usually don't have timetable info?
             if(class_component == "External")
               @logger.debug "Skipping external class"
-              throw :externalclass
+              throw :invalidclass
+            elsif(attendance == "On Line")
+              @logger.debug "Skipping online class"
+              throw :invalidclass
             else
               # Only save options if not external and not saved before
               if(topic == nil)


### PR DESCRIPTION
Online classes such as those found in BIOL1007[1] are missing a day of the week, and were causing the unibuddy api to 500 when timetabling these classes.
These classes don't make much sense to include in timetabling anyway as they have bogus start time, so now they are skipped.

[1] http://timetable.unisa.edu.au/public/timetable/ClassTimetable.aspx?CourseId=008333&TermCode=1710